### PR TITLE
Add proxy support

### DIFF
--- a/src/README/inputs.conf.spec
+++ b/src/README/inputs.conf.spec
@@ -19,3 +19,6 @@ password = <value>
 
 clean_html = <value>
 * Indicates if the HTML content in the output to human readable text
+
+proxy = <value>
+* Defines the proxy through which connection will be made via


### PR DESCRIPTION
**bin/syndication.py**
- import  ProxyHandler for urllib.request and urllib2
- In class SyndicationModularInput
    - init method, add URLField in args to allow for a proxy URL.
    - Add a classmethod get_proxy_handler (made similar to get_auth_handler) to create the proxy_handler object.
    - get_feed method
         - changed to include proxy parameter
         - If the proxy parameter is not None, call get_proxy_handler to create the object proxy_handler
             - Also ensure that the build_opener call uses the proxy_handler object.
         - run method
             - add proxy parameter (cleaned_params["proxy"])
             - call to self.get_feed includes the new proxy parameter


**README/inputs.conf.spec**
- Added proxy parameter (splunk errors if I don't add this)
   proxy = <value>
   * Defines the proxy through which connection will be made via
